### PR TITLE
Search no default params

### DIFF
--- a/src/main/java/gateway/controller/DataController.java
+++ b/src/main/java/gateway/controller/DataController.java
@@ -93,7 +93,7 @@ public class DataController extends PiazzaRestController {
 
 	private static final String DEFAULT_PAGE_SIZE = "10";
 	private static final String DEFAULT_PAGE = "0";
-	private static final String DEFAULT_ORDER = "asc";
+	private static final String DEFAULT_ORDER = "desc";
 	private static final String DEFAULT_SORTBY = "metadata.createdOn";
 	private static final String DEFAULT_SORTBY_ES = "dataResource.metadata.createdOn"; //schema for Elasticsearch
 	private RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/gateway/controller/DataController.java
+++ b/src/main/java/gateway/controller/DataController.java
@@ -467,12 +467,6 @@ public class DataController extends PiazzaRestController {
 			@ApiResponse(code = 500, message = "Internal Error", response = ErrorResponse.class) })
 	public ResponseEntity<PiazzaResponse> searchData(
 			@ApiParam(value = "The Query string for the Search component.", required = true) @Valid @RequestBody SearchRequest query,
-			/*
-			@ApiParam(value = "Paginating large datasets. This will determine the starting page for the query.") @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) Integer page,
-			@ApiParam(value = "The number of results to be returned per query.") @RequestParam(value = "perPage", required = false, defaultValue = DEFAULT_PAGE_SIZE) Integer perPage,
-			@ApiParam(value = "Indicates ascending or descending order.") @RequestParam(value = "order", required = false, defaultValue = DEFAULT_ORDER) String order,
-			@ApiParam(value = "The data field to sort by.") @RequestParam(value = "sortBy", required = false, defaultValue = DEFAULT_SORTBY_ES) String sortBy,
-*/
 			@ApiParam(value = "Paginating large datasets. This will determine the starting page for the query.") @RequestParam(value = "page", required = false) Integer page,
 			@ApiParam(value = "The number of results to be returned per query.") @RequestParam(value = "perPage", required = false) Integer perPage,
 			@ApiParam(value = "Indicates ascending or descending order.") @RequestParam(value = "order", required = false) String order,
@@ -482,16 +476,19 @@ public class DataController extends PiazzaRestController {
 			// Log the request
 			logger.log(String.format("User %s sending a complex query for Search.", gatewayUtil.getPrincipalName(user)),
 					PiazzaLogger.INFO);
+			
 			// Send the query to the Pz-Search component
 			HttpHeaders headers = new HttpHeaders();
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<Object> entity = new HttpEntity<Object>(query, headers);
-			String parampage = page == null ? "" : "page=" + page.toString();
-			String paramperPage = perPage == null ? "" : "perPage=" + perPage.toString();
-			String paramorder = order == null ? "" : "order=" + order;
-			String paramsortBy = sortBy == null ? "" : "sortBy=" + sortBy;
+			
+			String paramPage = (page == null) ? "" : "page=" + page.toString();
+			String paramPerPage = (perPage == null) ? "" : "perPage=" + perPage.toString();
+			String paramOrder = (order == null) ? "" : "order=" + order;
+			String paramSortBy = (sortBy == null) ? "" : "sortBy=" + sortBy;
+			
 			DataResourceListResponse searchResponse = restTemplate.postForObject(
-					String.format("%s/%s?%s&%s&%s&%s", SEARCH_URL, SEARCH_ENDPOINT, parampage, paramperPage, paramorder, paramsortBy), entity, DataResourceListResponse.class);
+					String.format("%s/%s?%s&%s&%s&%s", SEARCH_URL, SEARCH_ENDPOINT, paramPage, paramPerPage, paramOrder, paramSortBy), entity, DataResourceListResponse.class);
 			// Respond
 			return new ResponseEntity<PiazzaResponse>(searchResponse, HttpStatus.OK);
 		} catch (Exception exception) {

--- a/src/main/java/gateway/controller/DataController.java
+++ b/src/main/java/gateway/controller/DataController.java
@@ -467,10 +467,16 @@ public class DataController extends PiazzaRestController {
 			@ApiResponse(code = 500, message = "Internal Error", response = ErrorResponse.class) })
 	public ResponseEntity<PiazzaResponse> searchData(
 			@ApiParam(value = "The Query string for the Search component.", required = true) @Valid @RequestBody SearchRequest query,
+			/*
 			@ApiParam(value = "Paginating large datasets. This will determine the starting page for the query.") @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) Integer page,
 			@ApiParam(value = "The number of results to be returned per query.") @RequestParam(value = "perPage", required = false, defaultValue = DEFAULT_PAGE_SIZE) Integer perPage,
 			@ApiParam(value = "Indicates ascending or descending order.") @RequestParam(value = "order", required = false, defaultValue = DEFAULT_ORDER) String order,
 			@ApiParam(value = "The data field to sort by.") @RequestParam(value = "sortBy", required = false, defaultValue = DEFAULT_SORTBY_ES) String sortBy,
+*/
+			@ApiParam(value = "Paginating large datasets. This will determine the starting page for the query.") @RequestParam(value = "page", required = false) Integer page,
+			@ApiParam(value = "The number of results to be returned per query.") @RequestParam(value = "perPage", required = false) Integer perPage,
+			@ApiParam(value = "Indicates ascending or descending order.") @RequestParam(value = "order", required = false) String order,
+			@ApiParam(value = "The data field to sort by.") @RequestParam(value = "sortBy", required = false) String sortBy,
 			Principal user) {
 		try {
 			// Log the request
@@ -480,8 +486,12 @@ public class DataController extends PiazzaRestController {
 			HttpHeaders headers = new HttpHeaders();
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<Object> entity = new HttpEntity<Object>(query, headers);
+			String parampage = page == null ? "" : "page=" + page.toString();
+			String paramperPage = perPage == null ? "" : "perPage=" + perPage.toString();
+			String paramorder = order == null ? "" : "order=" + order;
+			String paramsortBy = sortBy == null ? "" : "sortBy=" + sortBy;
 			DataResourceListResponse searchResponse = restTemplate.postForObject(
-					String.format("%s/%s?page=%s&perPage=%s&order=%s&sortBy=%s", SEARCH_URL, SEARCH_ENDPOINT, page, perPage, order, sortBy), entity, DataResourceListResponse.class);
+					String.format("%s/%s?%s&%s&%s&%s", SEARCH_URL, SEARCH_ENDPOINT, parampage, paramperPage, paramorder, paramsortBy), entity, DataResourceListResponse.class);
 			// Respond
 			return new ResponseEntity<PiazzaResponse>(searchResponse, HttpStatus.OK);
 		} catch (Exception exception) {


### PR DESCRIPTION
Responsibility for default parameters for search pagination and sorting should be within pz-search.  Remove default values in actual parameter list for search call.  Also change remaining default sort order to be "desc" so that most recent addition is first return for "createdOn" default "sortBy". 
